### PR TITLE
ci: fix release-please to use simple release-type

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,10 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          release-type: python
+          release-type: simple
+          package-name: morningstreams
+          version-file: morningstreams/__init__.py
           token: ${{ secrets.GITHUB_TOKEN }}
-          skip-github-release: false
 
   publish:
     needs: release


### PR DESCRIPTION
Switch from `python` to `simple` release-type with `version-file` pointing to `__init__.py`. This makes release-please respect the manifest version and correctly propose 1.0.0.